### PR TITLE
chore: update dependencies and add engine requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,29 @@
             "name": "chunknorris",
             "version": "0.1.0",
             "dependencies": {
-                "@material-ui/core": "^4.11.2",
+                "@material-ui/core": "^4.12.4",
                 "@material-ui/icons": "^4.11.3",
-                "@material-ui/lab": "^4.0.0-alpha.61",
-                "@testing-library/jest-dom": "^5.11.6",
-                "@testing-library/react": "^11.2.2",
-                "@testing-library/user-event": "^12.6.0",
-                "react": "^17.0.1",
-                "react-dom": "^17.0.1",
+                "@testing-library/jest-dom": "^5.17.0",
+                "@testing-library/react": "^12.1.5",
+                "@testing-library/user-event": "^14.5.2",
+                "react": "^17.0.2",
+                "react-dom": "^17.0.2",
                 "react-scripts": "^5.0.1",
-                "web-vitals": "^0.2.4"
+                "web-vitals": "^3.5.2"
             },
             "devDependencies": {
-                "gh-pages": "^3.2.3"
+                "gh-pages": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=9.0.0"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+            "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+            "license": "MIT"
         },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
@@ -2028,18 +2037,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/runtime-corejs3": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-            "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
-            "license": "MIT",
-            "dependencies": {
-                "core-js-pure": "^3.43.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/template": {
             "version": "7.27.2",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -2380,7 +2377,8 @@
         "node_modules/@emotion/hash": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+            "license": "MIT"
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.0",
@@ -3164,16 +3162,17 @@
             "license": "MIT"
         },
         "node_modules/@material-ui/core": {
-            "version": "4.11.2",
-            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.2.tgz",
-            "integrity": "sha512-/D1+AQQeYX/WhT/FUk78UCRj8ch/RCglsQLYujYTIqPSJlwZHKcvHidNeVhODXeApojeXjkl0tWdk5C9ofwOkQ==",
+            "version": "4.12.4",
+            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
+            "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
             "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.4.4",
-                "@material-ui/styles": "^4.11.2",
-                "@material-ui/system": "^4.11.2",
-                "@material-ui/types": "^5.1.0",
-                "@material-ui/utils": "^4.11.2",
+                "@material-ui/styles": "^4.11.5",
+                "@material-ui/system": "^4.12.2",
+                "@material-ui/types": "5.1.0",
+                "@material-ui/utils": "^4.11.3",
                 "@types/react-transition-group": "^4.2.0",
                 "clsx": "^1.0.4",
                 "hoist-non-react-statics": "^3.3.2",
@@ -3223,55 +3222,28 @@
                 }
             }
         },
-        "node_modules/@material-ui/lab": {
-            "version": "4.0.0-alpha.61",
-            "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
-            "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
+        "node_modules/@material-ui/styles": {
+            "version": "4.11.5",
+            "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+            "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
             "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.4.4",
-                "@material-ui/utils": "^4.11.3",
-                "clsx": "^1.0.4",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "peerDependencies": {
-                "@material-ui/core": "^4.12.1",
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@material-ui/styles": {
-            "version": "4.11.2",
-            "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.2.tgz",
-            "integrity": "sha512-xbItf8zkfD3FuGoD9f2vlcyPf9jTEtj9YTJoNNV+NMWaSAHXgrW6geqRoo/IwBuMjqpwqsZhct13e2nUyU9Ljw==",
-            "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
                 "@emotion/hash": "^0.8.0",
-                "@material-ui/types": "^5.1.0",
-                "@material-ui/utils": "^4.11.2",
+                "@material-ui/types": "5.1.0",
+                "@material-ui/utils": "^4.11.3",
                 "clsx": "^1.0.4",
                 "csstype": "^2.5.2",
                 "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.0.3",
-                "jss-plugin-camel-case": "^10.0.3",
-                "jss-plugin-default-unit": "^10.0.3",
-                "jss-plugin-global": "^10.0.3",
-                "jss-plugin-nested": "^10.0.3",
-                "jss-plugin-props-sort": "^10.0.3",
-                "jss-plugin-rule-value-function": "^10.0.3",
-                "jss-plugin-vendor-prefixer": "^10.0.3",
+                "jss": "^10.5.1",
+                "jss-plugin-camel-case": "^10.5.1",
+                "jss-plugin-default-unit": "^10.5.1",
+                "jss-plugin-global": "^10.5.1",
+                "jss-plugin-nested": "^10.5.1",
+                "jss-plugin-props-sort": "^10.5.1",
+                "jss-plugin-rule-value-function": "^10.5.1",
+                "jss-plugin-vendor-prefixer": "^10.5.1",
                 "prop-types": "^15.7.2"
             },
             "engines": {
@@ -3293,13 +3265,13 @@
             }
         },
         "node_modules/@material-ui/system": {
-            "version": "4.11.2",
-            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.2.tgz",
-            "integrity": "sha512-BELFJEel5E+5DMiZb6XXT3peWRn6UixRvBtKwSxqntmD0+zwbbfCij6jtGwwdJhN1qX/aXrKu10zX31GBaeR7A==",
-            "deprecated": "You can now upgrade to @mui/system. See the guide: https://mui.com/guides/migration-v4/",
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
+            "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.4.4",
-                "@material-ui/utils": "^4.11.2",
+                "@material-ui/utils": "^4.11.3",
                 "csstype": "^2.5.2",
                 "prop-types": "^15.7.2"
             },
@@ -3325,6 +3297,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
             "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+            "license": "MIT",
             "peerDependencies": {
                 "@types/react": "*"
             },
@@ -3825,34 +3798,69 @@
             }
         },
         "node_modules/@testing-library/dom": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.29.0.tgz",
-            "integrity": "sha512-0hhuJSmw/zLc6ewR9cVm84TehuTd7tbqBX9pRNSp8znJ9gTmSgesdbiGZtt8R6dL+2rgaPFp9Yjr7IU1HWm49w==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+            "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^4.2.0",
-                "aria-query": "^4.2.2",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.1.3",
                 "chalk": "^4.1.0",
-                "dom-accessibility-api": "^0.5.4",
-                "lz-string": "^1.4.4",
-                "pretty-format": "^26.6.2"
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "pretty-format": "^27.0.2"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
-        "node_modules/@testing-library/jest-dom": {
-            "version": "5.11.6",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz",
-            "integrity": "sha512-cVZyUNRWwUKI0++yepYpYX7uhrP398I+tGz4zOlLVlUYnZS+Svuxv4fwLeCIy7TnBYKXUaOlQr3vopxL8ZfEnA==",
+        "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "license": "MIT",
             "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
+            "integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.0.1",
                 "@babel/runtime": "^7.9.2",
                 "@types/testing-library__jest-dom": "^5.9.1",
-                "aria-query": "^4.2.2",
+                "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
-                "css": "^3.0.0",
                 "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.5.6",
                 "lodash": "^4.17.15",
                 "redent": "^3.0.0"
             },
@@ -3860,6 +3868,15 @@
                 "node": ">=8",
                 "npm": ">=6",
                 "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/@testing-library/jest-dom/node_modules/chalk": {
@@ -3874,59 +3891,31 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@testing-library/jest-dom/node_modules/css": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.6.0"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/source-map-resolve": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-            "dependencies": {
-                "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0"
-            }
-        },
         "node_modules/@testing-library/react": {
-            "version": "11.2.2",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.2.tgz",
-            "integrity": "sha512-jaxm0hwUjv+hzC+UFEywic7buDC9JQ1q3cDsrWVSDAPmLotfA6E6kUHlYm/zOeGCac6g48DR36tFHxl7Zb+N5A==",
+            "version": "12.1.5",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
+            "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^7.28.1"
+                "@testing-library/dom": "^8.0.0",
+                "@types/react-dom": "<18.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             },
             "peerDependencies": {
-                "react": "*",
-                "react-dom": "*"
+                "react": "<18.0.0",
+                "react-dom": "<18.0.0"
             }
         },
         "node_modules/@testing-library/user-event": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.0.tgz",
-            "integrity": "sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.12.5"
-            },
+            "version": "14.6.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+            "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+            "license": "MIT",
             "engines": {
-                "node": ">=10",
+                "node": ">=12",
                 "npm": ">=6"
             },
             "peerDependencies": {
@@ -3952,9 +3941,10 @@
             }
         },
         "node_modules/@types/aria-query": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
-            "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A=="
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -4231,6 +4221,15 @@
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "17.0.26",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
+            "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^17.0.0"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -5051,15 +5050,12 @@
             }
         },
         "node_modules/aria-query": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+            "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime": "^7.10.2",
-                "@babel/runtime-corejs3": "^7.10.2"
-            },
-            "engines": {
-                "node": ">=6.0"
+                "deep-equal": "^2.0.5"
             }
         },
         "node_modules/array-buffer-byte-length": {
@@ -5113,15 +5109,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/array.prototype.findlast": {
@@ -5273,14 +5260,10 @@
             "license": "MIT"
         },
         "node_modules/async": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "license": "MIT"
         },
         "node_modules/async-function": {
             "version": "1.0.0",
@@ -5304,17 +5287,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "bin": {
-                "atob": "bin/atob.js"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
             }
         },
         "node_modules/autoprefixer": {
@@ -6691,6 +6663,7 @@
             "version": "2.0.8",
             "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
             "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.8.3",
                 "is-in-browser": "^1.0.2"
@@ -6882,9 +6855,10 @@
             "license": "MIT"
         },
         "node_modules/csstype": {
-            "version": "2.6.14",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-            "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+            "version": "2.6.21",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+            "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+            "license": "MIT"
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -6980,20 +6954,43 @@
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "license": "MIT"
         },
-        "node_modules/decode-uri-component": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
             "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
             "license": "MIT"
+        },
+        "node_modules/deep-equal": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "call-bind": "^1.0.5",
+                "es-get-iterator": "^1.1.3",
+                "get-intrinsic": "^1.2.2",
+                "is-arguments": "^1.1.1",
+                "is-array-buffer": "^3.0.2",
+                "is-date-object": "^1.0.5",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "isarray": "^2.0.5",
+                "object-is": "^1.1.5",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.5.1",
+                "side-channel": "^1.0.4",
+                "which-boxed-primitive": "^1.0.2",
+                "which-collection": "^1.0.1",
+                "which-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -7197,9 +7194,10 @@
             }
         },
         "node_modules/dom-accessibility-api": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
-            "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ=="
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "license": "MIT"
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -7211,18 +7209,20 @@
             }
         },
         "node_modules/dom-helpers": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
-            "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/dom-helpers/node_modules/csstype": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-            "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
         },
         "node_modules/dom-serializer": {
             "version": "1.4.1",
@@ -7379,10 +7379,11 @@
             "license": "ISC"
         },
         "node_modules/email-addresses": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
-            "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
-            "dev": true
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+            "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/emittery": {
             "version": "0.8.1",
@@ -7550,6 +7551,26 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-get-iterator": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "has-symbols": "^1.0.3",
+                "is-arguments": "^1.1.1",
+                "is-map": "^2.0.2",
+                "is-set": "^2.0.2",
+                "is-string": "^1.0.7",
+                "isarray": "^2.0.5",
+                "stop-iteration-iterator": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-iterator-helpers": {
@@ -9176,18 +9197,19 @@
             }
         },
         "node_modules/gh-pages": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
-            "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+            "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "async": "^2.6.1",
-                "commander": "^2.18.0",
-                "email-addresses": "^3.0.1",
+                "async": "^3.2.4",
+                "commander": "^13.0.0",
+                "email-addresses": "^5.0.0",
                 "filenamify": "^4.3.0",
                 "find-cache-dir": "^3.3.1",
-                "fs-extra": "^8.1.0",
-                "globby": "^6.1.0"
+                "fs-extra": "^11.1.1",
+                "globby": "^11.1.0"
             },
             "bin": {
                 "gh-pages": "bin/gh-pages.js",
@@ -9197,70 +9219,29 @@
                 "node": ">=10"
             }
         },
-        "node_modules/gh-pages/node_modules/array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "dependencies": {
-                "array-uniq": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/gh-pages/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/gh-pages/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "version": "11.3.2",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+            "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/gh-pages/node_modules/globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gh-pages/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dev": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/gh-pages/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/glob": {
@@ -9540,6 +9521,7 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "react-is": "^16.7.0"
             }
@@ -9809,9 +9791,10 @@
             }
         },
         "node_modules/hyphenate-style-name": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+            "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -9926,14 +9909,6 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/indefinite-observable": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
-            "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
-            "dependencies": {
-                "symbol-observable": "1.2.0"
-            }
-        },
         "node_modules/indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -9984,6 +9959,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-array-buffer": {
@@ -10222,7 +10213,8 @@
         "node_modules/is-in-browser": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-            "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+            "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==",
+            "license": "MIT"
         },
         "node_modules/is-map": {
             "version": "2.0.3",
@@ -10658,12 +10650,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/jake/node_modules/async": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-            "license": "MIT"
         },
         "node_modules/jest": {
             "version": "27.5.1",
@@ -12574,13 +12560,13 @@
             }
         },
         "node_modules/jss": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.0.tgz",
-            "integrity": "sha512-B6151NvG+thUg3murLNHRPLxTLwQ13ep4SH5brj4d8qKtogOx/jupnpfkPGSHPqvcwKJaCLctpj2lEk+5yGwMw==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+            "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
                 "csstype": "^3.0.2",
-                "indefinite-observable": "^2.0.1",
                 "is-in-browser": "^1.1.3",
                 "tiny-warning": "^1.0.2"
             },
@@ -12590,76 +12576,84 @@
             }
         },
         "node_modules/jss-plugin-camel-case": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.0.tgz",
-            "integrity": "sha512-GSjPL0adGAkuoqeYiXTgO7PlIrmjv5v8lA6TTBdfxbNYpxADOdGKJgIEkffhlyuIZHlPuuiFYTwUreLUmSn7rg==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+            "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
                 "hyphenate-style-name": "^1.0.3",
-                "jss": "10.5.0"
+                "jss": "10.10.0"
             }
         },
         "node_modules/jss-plugin-default-unit": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.0.tgz",
-            "integrity": "sha512-rsbTtZGCMrbcb9beiDd+TwL991NGmsAgVYH0hATrYJtue9e+LH/Gn4yFD1ENwE+3JzF3A+rPnM2JuD9L/SIIWw==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+            "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.5.0"
+                "jss": "10.10.0"
             }
         },
         "node_modules/jss-plugin-global": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.0.tgz",
-            "integrity": "sha512-FZd9+JE/3D7HMefEG54fEC0XiQ9rhGtDHAT/ols24y8sKQ1D5KIw6OyXEmIdKFmACgxZV2ARQ5pAUypxkk2IFQ==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+            "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.5.0"
+                "jss": "10.10.0"
             }
         },
         "node_modules/jss-plugin-nested": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.0.tgz",
-            "integrity": "sha512-ejPlCLNlEGgx8jmMiDk/zarsCZk+DV0YqXfddpgzbO9Toamo0HweCFuwJ3ZO40UFOfqKwfpKMVH/3HUXgxkTMg==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+            "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.5.0",
+                "jss": "10.10.0",
                 "tiny-warning": "^1.0.2"
             }
         },
         "node_modules/jss-plugin-props-sort": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.0.tgz",
-            "integrity": "sha512-kTLRvrOetFKz5vM88FAhLNeJIxfjhCepnvq65G7xsAQ/Wgy7HwO1BS/2wE5mx8iLaAWC6Rj5h16mhMk9sKdZxg==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+            "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.5.0"
+                "jss": "10.10.0"
             }
         },
         "node_modules/jss-plugin-rule-value-function": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.0.tgz",
-            "integrity": "sha512-jXINGr8BSsB13JVuK274oEtk0LoooYSJqTBCGeBu2cG/VJ3+4FPs1gwLgsq24xTgKshtZ+WEQMVL34OprLidRA==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+            "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.5.0",
+                "jss": "10.10.0",
                 "tiny-warning": "^1.0.2"
             }
         },
         "node_modules/jss-plugin-vendor-prefixer": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.0.tgz",
-            "integrity": "sha512-rux3gmfwDdOKCLDx0IQjTwTm03IfBa+Rm/hs747cOw5Q7O3RaTUIMPKjtVfc31Xr/XI9Abz2XEupk1/oMQ7zRA==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+            "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
                 "css-vendor": "^2.0.8",
-                "jss": "10.5.0"
+                "jss": "10.10.0"
             }
         },
         "node_modules/jss/node_modules/csstype": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-            "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
         },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
@@ -12882,9 +12876,10 @@
             }
         },
         "node_modules/lz-string": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-            "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "license": "MIT",
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -13326,6 +13321,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object-is": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -13760,27 +13771,6 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "dependencies": {
-                "pinkie": "^2.0.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -15373,9 +15363,10 @@
             }
         },
         "node_modules/react": {
-            "version": "17.0.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-            "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -15519,16 +15510,17 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "17.0.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-            "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+            "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
-                "scheduler": "^0.20.1"
+                "scheduler": "^0.20.2"
             },
             "peerDependencies": {
-                "react": "17.0.1"
+                "react": "17.0.2"
             }
         },
         "node_modules/react-error-overlay": {
@@ -15625,9 +15617,10 @@
             }
         },
         "node_modules/react-transition-group": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
-            "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "dom-helpers": "^5.0.1",
@@ -16220,9 +16213,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-            "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+            "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -17390,14 +17384,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/symbol-observable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -17493,6 +17479,20 @@
                 "yaml": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/tailwindcss/node_modules/yaml": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
             }
         },
         "node_modules/tapable": {
@@ -17677,7 +17677,8 @@
         "node_modules/tiny-warning": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+            "license": "MIT"
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -17952,6 +17953,20 @@
             "license": "MIT",
             "dependencies": {
                 "is-typedarray": "^1.0.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "node_modules/unbox-primitive": {
@@ -18235,9 +18250,10 @@
             }
         },
         "node_modules/web-vitals": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
-            "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+            "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
+            "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
             "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -3,17 +3,20 @@
     "name": "chunknorris",
     "version": "0.1.0",
     "private": true,
+    "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+    },
     "dependencies": {
-        "@material-ui/core": "^4.11.2",
+        "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
-        "@material-ui/lab": "^4.0.0-alpha.61",
-        "@testing-library/jest-dom": "^5.11.6",
-        "@testing-library/react": "^11.2.2",
-        "@testing-library/user-event": "^12.6.0",
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^12.1.5",
+        "@testing-library/user-event": "^14.5.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "react-scripts": "^5.0.1",
-        "web-vitals": "^0.2.4"
+        "web-vitals": "^3.5.2"
     },
     "scripts": {
         "predeploy": "npm run build",
@@ -43,6 +46,6 @@
     },
     "proxy": "https://api.chucknorris.io",
     "devDependencies": {
-        "gh-pages": "^3.2.3"
+        "gh-pages": "^6.3.0"
     }
 }


### PR DESCRIPTION
- Updated @material-ui/core from ^4.11.2 to ^4.12.4
- Updated @testing-library/jest-dom from ^5.11.6 to ^5.17.0
- Updated @testing-library/react from ^11.2.2 to ^12.1.5
- Updated @testing-library/user-event from ^12.6.0 to ^14.5.2
- Updated react from ^17.0.1 to ^17.0.2
- Updated react-dom from ^17.0.1 to ^17.0.2
- Updated web-vitals from ^0.2.4 to ^3.5.2
- Updated gh-pages from ^3.2.3 to ^6.3.0
- Added engines field to specify required Node and npm versions